### PR TITLE
Fix broken exception

### DIFF
--- a/src/LoginRadiusSDK/Clients/DefaultHttpClient.php
+++ b/src/LoginRadiusSDK/Clients/DefaultHttpClient.php
@@ -67,7 +67,7 @@ class DefaultHttpClient implements IHttpClient {
         if (!empty($response)) {
             $result = json_decode($response);
             if (isset($result->ErrorCode) && !empty($result->ErrorCode)) {
-                throw new LoginRadiusException($result->Message, $result);
+                throw new LoginRadiusException($result->Message, (array)$result);
             }
         }
         return $response;


### PR DESCRIPTION
`LoginRadiusException` expects the second parameter to be an array.