### PR TITLE
/sott API returns JSON

### DIFF
--- a/src/LoginRadiusSDK/CustomerRegistration/Account/AccountAPI.php
+++ b/src/LoginRadiusSDK/CustomerRegistration/Account/AccountAPI.php
@@ -311,7 +311,7 @@ class AccountAPI {
      * @return type object
      */
     public function generateSOTT($time_difference = '10', $fields = '*') {
-        return $this->apiClientHandler("/sott", array('timedifference' => $time_difference, 'fields' => $fields));
+        return $this->apiClientHandler("/sott", array('timedifference' => $time_difference, 'fields' => $fields), array('output_format' => 'json'));
     }
 
     /**


### PR DESCRIPTION
Functions consuming `generateSOTT()` expect a `$response` object with a `Sott` property. In order to return this `apiClient` needs `array('output_format' => 'json')`